### PR TITLE
Avoid redundant distance calculations

### DIFF
--- a/nbp/neighbours.py
+++ b/nbp/neighbours.py
@@ -37,7 +37,6 @@ class Neighbours:
         self._verbose = verbose
         self.SystemInfo = system_info
         self.SystemState = system_state
-        # It might be possible to merge info and state into this.
         self.System = system
         self._box_length = self.SystemInfo.char_length()
         self._skin_radius = self.SystemInfo.worse_sigma() * 3
@@ -45,6 +44,12 @@ class Neighbours:
         self._subcells_inrow = 1
         self._subcell_length = self._create_subcells()
         self._neighbour_list = self._create_neighbours()
+
+        # Empty frame for the neighbours
+        self._neighbours_frame_IDs = None
+        self._neighbours_frame_dist = None
+        self._create_neighbours_frame()
+
         # variables needed for update
         self._last_update = 0
         self._update_count = 0
@@ -141,6 +146,9 @@ class Neighbours:
         System state (e.g. box length etc) should be the same.
         :return:new neighbour list.
         """
+        # update the frame each time:
+        self._create_neighbours_frame()
+        
         # get positions from last update
         positions_old = self.System.states()[self._last_update].positions()
         # get current positions
@@ -164,17 +172,19 @@ class Neighbours:
 
         return self._neighbour_list
 
-    def get_neighbours(self, particle_pos):
+
+    def _neighbours_for_one(self, particle_ID):
         """
         Calculate which neighbours are around the particle.
         Calculates the distance between a particle and its neighbours
         :param particle_pos: 3d coordinates of single particle
-        :return: array of neighbour particles and array with distances
+        :return: array of neighbour particles ID and array with distances
         """
         positions = self.SystemState.positions()
-        neighbours = []           # neighbour positions
+        particle_pos = positions[particle_ID]
+        neighbours = []  # neighbour positions
         neighbours_distance = []  # distance of particle to each neighbour
-        new_neighbours = []       # only neighbours within cutoff radius
+        new_neighbours = []  # only neighbours within cutoff radius
         neighbour_subcells = self._get_neighbours_subcells(particle_pos)
         # get starting positions for each subcell
         start_array = np.asarray(self._start_index)
@@ -195,38 +205,128 @@ class Neighbours:
         nb_length = np.shape(neighbours)[0]
         if self._verbose:
             print("neighbour length:", nb_length)
-        recent_neighbours = []
+
         # get distance from particle to neighbours
         for i in range(nb_length):
             index = neighbours[i]
-            x_distance = abs(particle_pos[0] - positions[index][0])
-            y_distance = abs(particle_pos[1] - positions[index][1])
-            z_distance = abs(particle_pos[2] - positions[index][2])
+            # only do this calculation for distances that have not been calculated before
+            if index > particle_ID:
+                x_distance = abs(particle_pos[0] - positions[index][0])
+                y_distance = abs(particle_pos[1] - positions[index][1])
+                z_distance = abs(particle_pos[2] - positions[index][2])
 
-            # correct boundary subcells distance.
-            l = 2*self._subcell_length  # max possible distance
-            if x_distance > l:
-                x_distance = self._box_length - x_distance
-            if y_distance > l:
-                y_distance = self._box_length - y_distance
-            if z_distance > l:
-                z_distance = self._box_length - z_distance
+                # correct boundary subcells distance.
+                l = 2 * self._subcell_length  # max possible distance
+                if x_distance > l:
+                    x_distance = self._box_length - x_distance
+                if y_distance > l:
+                    y_distance = self._box_length - y_distance
+                if z_distance > l:
+                    z_distance = self._box_length - z_distance
 
-            distance_3d = np.array([x_distance, y_distance, z_distance])
+                distance_3d = np.array([x_distance, y_distance, z_distance])
 
-            distance = np.linalg.norm(distance_3d)
-            # print("distance: ", distance)
-            # distance no further than cutoff radius:
-            if 0 < distance <= self.SystemInfo.cutoff():
-                neighbours_distance.append(distance)
-                new_neighbours.append(index)
+                distance = np.linalg.norm(distance_3d)
+                # print("distance: ", distance)
+                # distance no further than cutoff radius:
+                if 0 < distance <= self.SystemInfo.cutoff():
+                    neighbours_distance.append(distance)
+                    new_neighbours.append(index)
 
         # overwrite neighbours with the correct ones.
         neighbours = new_neighbours
 
         # Create namedtuple for easy access of output
-        Result = collections.namedtuple("Neighbour_result", ["nb_pos", "nb_dist"])
-        r = Result(nb_pos=neighbours, nb_dist=neighbours_distance)
+        Result = collections.namedtuple("Neighbour_result", ["nb_ID", "nb_dist"])
+        r = Result(nb_ID=neighbours, nb_dist=neighbours_distance)
+
+        return r
+
+
+    def _create_neighbours_frame(self):
+        """
+        Create a data frame -> Dictionary which contains the particle IDs for the neighbours
+        and the distances.
+        There are two dictionaries. One for the neighbour IDs and one for the distance.
+        As key the number of the neighbour is used.
+        """
+        particle_number = self.SystemInfo.num_particles()
+        self._neighbours_frame_IDs = {}
+        self._neighbours_frame_dist = {}
+
+        for i in range(particle_number):
+            nb = self._neighbours_for_one(i)
+            if not nb:
+                key = i
+                if key in self._neighbours_frame_IDs.keys():
+                    print("ERROR: A dictionary key for a neighbour has been "
+                          "found that should not exist!")
+            else:
+                key = i
+                if key not in self._neighbours_frame_IDs.keys():
+                    self._neighbours_frame_IDs[i] = nb.nb_ID
+                    self._neighbours_frame_dist[i] = nb.nb_dist
+                    # Already save the distances for poth particles to avoid
+                    # calculating them twice.
+                    nb_index = 0
+                    for j in nb.nb_ID:
+                        if j not in self._neighbours_frame_IDs.keys():
+                            self._neighbours_frame_IDs[j] = i
+                            self._neighbours_frame_dist[j] = nb.nb_dist[nb_index]
+                        else:
+                            existing_IDs = self._neighbours_frame_IDs[j]
+                            existing_dist = self._neighbours_frame_dist[j]
+                            # conversion to type list if needed
+                            if type(existing_IDs) is int:
+                                existing_IDs = [existing_IDs]
+                                existing_dist = [existing_dist]
+
+                            merged_IDs = existing_IDs + [i]
+                            merged_dist = existing_dist + nb.nb_dist[nb_index]
+
+                            self._neighbours_frame_IDs[j] = merged_IDs
+                            self._neighbours_frame_dist[j] = merged_dist
+                        nb_index = nb_index + 1
+                # if some values already exist then add the new ones to them.
+                else:
+                    existing_IDs = self._neighbours_frame_IDs[i]
+                    existing_dist = self._neighbours_frame_dist[i]
+                    if type(existing_IDs) is int:
+                        existing_IDs = [existing_IDs]
+                        existing_dist = [existing_dist]
+
+                    merged_IDs = existing_IDs + nb.nb_ID
+                    merged_dist = existing_dist + nb.nb_dist
+
+                    self._neighbours_frame_IDs[i] = merged_IDs
+                    self._neighbours_frame_dist[i] = merged_dist
+
+        pass
+
+    # def _get_neighbours_frame(self):
+    #     """
+    #     Call the frame that contains the neighbours for every particle and
+    #     the distances.
+    #     Getting the neighbours IDs: dataframe[particleID][0]
+    #     Getting the distances: dataframe[particleID][1]
+    #     :return: 3D neighbours data frame
+    #     """
+    #     return self._neighbours_frame_IDs, self._neighbours_frame_dist
+
+    def get_neighbours(self, particle_ID):
+        """
+        This gets the neighbours of a single particle and the distances to
+        its neighbours.
+        :param particle_ID: particle number
+        :return:
+        """
+        key = particle_ID
+        if key in self._neighbours_frame_IDs.keys():
+            neighbours = self._neighbours_frame_IDs[particle_ID]
+            neighbours_distance = self._neighbours_frame_dist[particle_ID]
+
+        Result = collections.namedtuple("Neighbour_result", ["nb_ID", "nb_dist"])
+        r = Result(nb_ID=neighbours, nb_dist=neighbours_distance)
 
         return r
 

--- a/nbp/sysmodule.py
+++ b/nbp/sysmodule.py
@@ -233,10 +233,10 @@ class SystemState:
                 self._potential = 0
                 particle_number = self._positions.size
                 for i in range(particle_number):
-                    neighbour = self.neighbours().get_neighbours(self._positions[i])
+                    neighbour = self.neighbours().get_neighbours(i)
                     for j in range(i + 1, particle_number):
-                        sigma = self.system().info().sigma_eff()[i][neighbour.nb_pos[j]]
-                        epsilon_lj = self.system().info().epsilon_lj_eff()[i][neighbour.nb_pos[j]]
+                        sigma = self.system().info().sigma_eff()[i][neighbour.nb_ID[j]]
+                        epsilon_lj = self.system().info().epsilon_lj_eff()[i][neighbour.nb_ID[j]]
                         distance = neighbour.nb_dist[j]
                         try:
                             pot_lj = self.calc_potential_lj(distance, epsilon_lj, sigma)
@@ -307,12 +307,12 @@ class SystemState:
                 nb = self.neighbours()
                 shortsum = 0
                 for i in range(len(pos)):
-                    neighbour = nb.get_neighbours(pos[i])
-                    for j in range(len(neighbour.nb_pos)):
+                    neighbour = nb.get_neighbours(i)
+                    for j in range(len(neighbour.nb_ID)):
                         if i != j:
                             distance = neighbour.nb_dist[j]
                             qi = charges[i]
-                            qj = charges[neighbour.nb_pos[j]]
+                            qj = charges[neighbour.nb_ID[j]]
                             shortsum += (qi * qj) / distance * sp.special.erfc(
                                 (np.linalg.norm(distance)) / (np.sqrt(2) * sigma[i, j]))
             else:
@@ -391,12 +391,12 @@ class SystemState:
             # forces resulting from short energy
             for i in range(len(pos)):
                 if self.system().info().use_neighbours():
-                    neighbour = nb.get_neighbours(pos[i])
+                    neighbour = nb.get_neighbours(i)
                     force_sum = 0
-                    for j in range(len(neighbour.nb_pos)):
+                    for j in range(len(neighbour.nb_ID)):
                         if i != j:
                             distance = neighbour.nb_dist[j]
-                            qj = charges[neighbour.nb_pos[j]]
+                            qj = charges[neighbour.nb_ID[j]]
                             force_sum += qj * distance / distance**2 \
                                          * ( sp.special.erfc( np.linalg.norm(distance)/np.sqrt(2)*sigma[i, j])/ np.linalg.norm(distance)) \
                                         + np.sqrt(2/np.pi) * sigma[i, j]**(-1) * np.exp(- np.linalg.norm(distance)**2 / 2* sigma[i, j]**2)

--- a/nbp/test_neighbours.py
+++ b/nbp/test_neighbours.py
@@ -33,7 +33,7 @@ def test_no_self_in_neighbours():
 
     self_in_neighbours = []
     for particle, position in enumerate(system.state().positions()):
-        result = system.state().neighbours().get_neighbours(position)
+        result = system.state().neighbours().get_neighbours(particle)
         if particle in result.nb_ID:
             self_in_neighbours.append(True)
         else:

--- a/nbp/test_neighbours.py
+++ b/nbp/test_neighbours.py
@@ -1,0 +1,182 @@
+import nbp
+import numpy as np
+
+def make_system(characteristic_length=10,
+                sigma=None, epsilon_lj=None, particle_charges=None, positions=None, particle_count=None,
+                lj=True, ewald=True, use_neighbours=False):
+    if particle_count is None:
+        if particle_charges is not None:
+            particle_count = np.asarray(particle_charges).shape[0]
+        elif positions is not None:
+            particle_count = np.asarray(positions).shape[0]
+        else:
+            particle_count = 50
+
+    if not sigma:
+        sigma = np.ones((particle_count, 1))
+    if not epsilon_lj:
+        epsilon_lj = np.ones((particle_count, 1))
+
+    if particle_charges is None:
+        particle_charges = np.random.rand(particle_count, 1)
+    if positions is None:
+        positions = characteristic_length * np.random.rand(particle_count, 3)
+
+    system = nbp.System(characteristic_length, sigma, epsilon_lj, particle_charges, positions,
+                        lj=lj, ewald=ewald, use_neighbours=use_neighbours)
+    nbp.Neighbours(system.info(), system.state(), system)
+    return system
+
+
+def test_no_self_in_neighbours():
+    system = make_system()
+
+    self_in_neighbours = []
+    for particle, position in enumerate(system.state().positions()):
+        result = system.state().neighbours().get_neighbours(position)
+        if particle in result.nb_ID:
+            self_in_neighbours.append(True)
+        else:
+            self_in_neighbours.append(False)
+
+    assert any(self_in_neighbours) is False
+
+
+def test_communicativity():
+    system = make_system()
+
+    for particle, position in enumerate(system.state().positions()):
+        result = system.state().neighbours().get_neighbours(particle)
+        nb_ID = result.nb_ID
+        nb_dist = result.nb_dist
+        print('Neighbours of particle {0}: {1}'.format(particle, nb_ID))
+        print('Distances from particle {0}: {1}'.format(particle, nb_dist))
+        for neighbour_index, neighbour in enumerate(nb_ID):
+            neighbour_result = system.state().neighbours().get_neighbours(
+                neighbour)
+            neighbour_neighbours = neighbour_result.nb_ID
+            print("neighbour dist: ", neighbour_result.nb_dist)
+            neighbour_dist = neighbour_result.nb_dist
+            print('Neighbours of particle {0}: {1}'.format(neighbour, neighbour_neighbours))
+            print('Distances from particle {0}: {1}'.format(neighbour, neighbour_dist))
+
+            if particle not in neighbour_neighbours:
+                assert particle in neighbour_neighbours
+
+            if neighbour_dist[neighbour_neighbours.index(particle)] != nb_dist[neighbour_index]:
+                assert neighbour_dist[neighbour_neighbours.index(particle)] == nb_dist[neighbour_index]
+        assert True
+
+test_communicativity()
+
+
+if 0:
+    def setup_neighbours(positions, particle_count, char_length, x):
+        charges = np.random.rand(particle_count, 1)
+        sigma = np.ones((particle_count, 1))
+        epsilon_lj = np.ones((particle_count, 1))
+        system = nbp.System(characteristic_length=char_length,
+                sigma=sigma, epsilon_lj=epsilon_lj, particle_charges=charges, positions=positions,
+                lj=True, ewald=True, use_neighbours=True)
+        neighbours = nbp.Neighbours(system.info(), system.state(), system, verbose=True)
+        neighbours_list = neighbours.get_neighbours(x)
+
+        return neighbours_list
+
+    if 0:
+        positions_set1 = 4 * np.random.random_sample((100, 3))
+        nb_result = setup_neighbours(positions_set1, len(positions_set1), 5, 8)
+
+        # Call the named tuple and show the positions and the distance
+        print("position result 1:", nb_result.nb_ID)
+        print("distance result 1:",  nb_result.nb_dist)
+        print("------------------End Test 1 ----------------------------- \n")
+
+    # Test if a real neighbour is seen as one.
+    for i in range(7):
+        positions_set2 = [[0, 0, 0], [1, 1.5, 1.2], [11, 11, 10], [5, 6, 5], [5, 5, 5], [8, 9, 10], [5.5, 6, 5.8]]
+        positions_set2 = np.asarray(positions_set2)
+        nb_result2 = setup_neighbours(positions_set2, len(positions_set2), 10, i)
+
+        # Call the named tuple and show the positions and the distance
+        print("\n position result 2 for {0}: ".format(i), nb_result2.nb_ID)
+        print("distance result 2:",  nb_result2.nb_dist)
+    print("--------------End Test 2 ----------------------------- \n")
+
+    # Test 3 if a real neighbour is seen as one.
+    positions_set3 = [[5, 5, 5], [5, 5, 8]]
+    positions_set3 = np.asarray(positions_set3)
+    nb_result3 = setup_neighbours(positions_set3, len(positions_set3), 10, 1)
+
+    # Call the named tuple and show the positions and the distance
+    print("position result 3:", nb_result3.nb_ID)
+    print("distance result 3:",  nb_result3.nb_dist)
+    print("---------------End Test 3 ----------------------------- \n")
+
+if 0:
+    def get_neighbour_frame(positions, particle_count, char_length):
+        charges = np.random.rand(particle_count, 1)
+        sigma = np.ones((particle_count, 1))
+        epsilon_lj = np.ones((particle_count, 1))
+        system = nbp.System(characteristic_length=char_length,
+                            sigma=sigma, epsilon_lj=epsilon_lj, particle_charges=charges, positions=positions,
+                            lj=True, ewald=True, use_neighbours=True)
+        neighbours = nbp.Neighbours(system.info(), system.state(), system, verbose=False)
+        neighbours_list = neighbours._get_neighbours_frame()
+
+        return neighbours_list
+
+
+    positions_set = [[0, 0, 0], [1, 1.5, 1.2], [11, 11, 10], [5, 6, 5], [5, 5, 5], [8, 9, 10], [5.5, 6, 5.8], [5.3, 5.8, 5.8]]
+    positions_set = np.asarray(positions_set)
+    dict_test = get_neighbour_frame(positions_set, len(positions_set), 10)
+
+    # Call the named tuple and show the positions and the distance
+    print("All IDs:", dict_test["IDs"])
+    print("All distances:", dict_test["Distance"])
+
+    for i in range(8):
+        if len(dict_test["IDs"][i]) != len(dict_test["Distance"][i]):
+            raise ValueError('Number of neighbours and distances is not the same')
+
+    print("--------------End Test 2 ----------------------------- \n")
+
+
+if 0:
+    def check_update(positions, particle_count, char_length, x):
+        charges = np.random.rand(particle_count, 1)
+        sigma = np.ones((particle_count, 1))
+        epsilon_lj = np.ones((particle_count, 1))
+        system = nbp.System(characteristic_length=char_length,
+                            sigma=sigma, epsilon_lj=epsilon_lj, particle_charges=charges, positions=positions,
+                            lj=True, ewald=True, use_neighbours=True)
+        neighbours = nbp.Neighbours(system.info(), system.state(), system, verbose=True)
+        beginning_list = neighbours.get_neighbours(x)
+
+        # new positions
+        positions = positions + 1
+        system.update_state()    # what has to go in here?
+        updated_list1 = neighbours.update_neighbours
+
+        positions = positions + 1
+        nbp.System(char_length, sigma, charges, positions)
+        updated_list2 = neighbours.update_neighbours
+
+        return beginning_list, updated_list1, updated_list2
+
+
+    positions_set = [[0, 0, 0], [1, 1.5, 1.2], [2, 2, 2]]
+    positions_set = np.asarray(positions_set)
+    nb_update = check_update(positions_set, len(positions_set), 10, 1, 1)
+
+    print("position result beginning:", nb_update[0].nb_ID)
+    print("distance result beginning:",  nb_update[0].nb_dist)
+    print("\n #----Next step: \n")
+    print("position result updated:", nb_update[1])
+    print("distance result updated:",  nb_update[1])
+    print("\n #----Next step: \n")
+    print("position result updated:", nb_update[2])
+    print("distance result updated:",  nb_update[2])
+
+    print("---------------End Test 4 ----------------------------- \n")
+

--- a/nbp/tests/test_neighbours.py
+++ b/nbp/tests/test_neighbours.py
@@ -1,7 +1,30 @@
 import nbp
 import numpy as np
 
-from .tools import make_system
+def make_system(characteristic_length=10,
+                sigma=None, epsilon_lj=None, particle_charges=None, positions=None, particle_count=None,
+                lj=True, ewald=True, use_neighbours=False):
+    if particle_count is None:
+        if particle_charges is not None:
+            particle_count = np.asarray(particle_charges).shape[0]
+        elif positions is not None:
+            particle_count = np.asarray(positions).shape[0]
+        else:
+            particle_count = 50
+
+    if not sigma:
+        sigma = np.ones((particle_count, 1))
+    if not epsilon_lj:
+        epsilon_lj = np.ones((particle_count, 1))
+
+    if particle_charges is None:
+        particle_charges = np.random.rand(particle_count, 1)
+    if positions is None:
+        positions = characteristic_length * np.random.rand(particle_count, 3)
+
+    system = nbp.System(characteristic_length, sigma, epsilon_lj, particle_charges, positions,
+                        lj=lj, ewald=ewald, use_neighbours=use_neighbours)
+    return system
 
 
 def test_no_self_in_neighbours():
@@ -10,7 +33,7 @@ def test_no_self_in_neighbours():
     self_in_neighbours = []
     for particle, position in enumerate(system.state().positions()):
         result = system.state().neighbours().get_neighbours(position)
-        if particle in result.nb_pos:
+        if particle in result.nb_ID:
             self_in_neighbours.append(True)
         else:
             self_in_neighbours.append(False)
@@ -22,15 +45,15 @@ def test_communicativity():
     system = make_system()
 
     for particle, position in enumerate(system.state().positions()):
-        result = system.state().neighbours().get_neighbours(position)
-        nb_pos = result.nb_pos
+        result = system.state().neighbours().get_neighbours(particle)
+        nb_ID = result.nb_ID
         nb_dist = result.nb_dist
-        print('Neighbours of particle {0}: {1}'.format(particle, nb_pos))
+        print('Neighbours of particle {0}: {1}'.format(particle, nb_ID))
         print('Distances from particle {0}: {1}'.format(particle, nb_dist))
-        for neighbour_index, neighbour in enumerate(nb_pos):
+        for neighbour_index, neighbour in enumerate(nb_ID):
             neighbour_result = system.state().neighbours().get_neighbours(
                 system.state().positions()[neighbour])
-            neighbour_neighbours = neighbour_result.nb_pos
+            neighbour_neighbours = neighbour_result.nb_ID
             neighbour_dist = neighbour_result.nb_dist
             print('Neighbours of particle {0}: {1}'.format(neighbour, neighbour_neighbours))
             print('Distances from particle {0}: {1}'.format(neighbour, neighbour_dist))
@@ -43,50 +66,58 @@ def test_communicativity():
         assert True
 
 
-if 0:
-    def setup_neighbours(positions, particle_number, char_length, sigma, x):
-        charges = np.random.random_sample((particle_number, 1))
-        system = nbp.System(char_length, sigma, charges, positions)
-        neighbours = nbp.Neighbours(system.info(), system.state(), system, verbose=True)
-        neighbours_list = neighbours.get_neighbours(positions[x])
+if 1:
+    def setup_neighbours(positions, particle_count, char_length, x):
+        charges = np.random.rand(particle_count, 1)
+        sigma = np.ones((particle_count, 1))
+        epsilon_lj = np.ones((particle_count, 1))
+        system = nbp.System(characteristic_length=char_length,
+                sigma=sigma, epsilon_lj=epsilon_lj, particle_charges=charges, positions=positions,
+                lj=True, ewald=True, use_neighbours=True)
+        neighbours = nbp.Neighbours(system.info(), system.state(), system, verbose=False)
+        neighbours_list = neighbours.get_neighbours(x)
 
         return neighbours_list
 
 
     positions_set1 = 4 * np.random.random_sample((100, 3))
-    nb_result = setup_neighbours(positions_set1, len(positions_set1), 5, 0.5, 8)
+    nb_result = setup_neighbours(positions_set1, len(positions_set1), 5, 8)
 
     # Call the named tuple and show the positions and the distance
-    print("position result 1:", nb_result.nb_pos)
+    print("position result 1:", nb_result.nb_ID)
     print("distance result 1:",  nb_result.nb_dist)
     print("------------------End Test 1 ----------------------------- \n")
 
     # Test if a real neighbour is seen as one.
-    positions_set2 = [[0, 0, 0], [1, 1.5, 1.2], [10, 10, 10]]
+    positions_set2 = [[0, 0, 0], [1, 1.5, 1.2], [11, 11, 10]]
     positions_set2 = np.asarray(positions_set2)
-    nb_result2 = setup_neighbours(positions_set2, len(positions_set2), 10, 1, 0)
+    nb_result2 = setup_neighbours(positions_set2, len(positions_set2), 10, 2)
 
     # Call the named tuple and show the positions and the distance
-    print("position result 2:", nb_result2.nb_pos)
+    print("position result 2:", nb_result2.nb_ID)
     print("distance result 2:",  nb_result2.nb_dist)
     print("--------------End Test 2 ----------------------------- \n")
 
     # Test 2 if a real neighbour is seen as one.
     positions_set3 = [[5, 5, 5], [5, 5, 8]]
     positions_set3 = np.asarray(positions_set3)
-    nb_result3 = setup_neighbours(positions_set3, len(positions_set3), 10, 1, 0)
+    nb_result3 = setup_neighbours(positions_set3, len(positions_set3), 10, 1)
 
     # Call the named tuple and show the positions and the distance
-    print("position result 3:", nb_result3.nb_pos)
+    print("position result 3:", nb_result3.nb_ID)
     print("distance result 3:",  nb_result3.nb_dist)
     print("---------------End Test 3 ----------------------------- \n")
 
 if 0:
-    def check_update(positions, particle_number, char_length, sigma, x):
-        charges = np.random.random_sample((particle_number, 1))
-        system = nbp.System(char_length, sigma, charges, positions)
+    def check_update(positions, particle_count, char_length, x):
+        charges = np.random.rand(particle_count, 1)
+        sigma = np.ones((particle_count, 1))
+        epsilon_lj = np.ones((particle_count, 1))
+        system = nbp.System(characteristic_length=char_length,
+                            sigma=sigma, epsilon_lj=epsilon_lj, particle_charges=charges, positions=positions,
+                            lj=True, ewald=True, use_neighbours=True)
         neighbours = nbp.Neighbours(system.info(), system.state(), system, verbose=True)
-        beginning_list = neighbours.get_neighbours(positions[x])
+        beginning_list = neighbours.get_neighbours(x)
 
         # new positions
         positions = positions + 1
@@ -104,7 +135,7 @@ if 0:
     positions_set = np.asarray(positions_set)
     nb_update = check_update(positions_set, len(positions_set), 10, 1, 1)
 
-    print("position result beginning:", nb_update[0].nb_pos)
+    print("position result beginning:", nb_update[0].nb_ID)
     print("distance result beginning:",  nb_update[0].nb_dist)
     print("\n #----Next step: \n")
     print("position result updated:", nb_update[1])

--- a/nbp/tests/test_neighbours.py
+++ b/nbp/tests/test_neighbours.py
@@ -1,6 +1,7 @@
 import nbp
 import numpy as np
 
+
 def make_system(characteristic_length=10,
                 sigma=None, epsilon_lj=None, particle_charges=None, positions=None, particle_count=None,
                 lj=True, ewald=True, use_neighbours=False):
@@ -65,14 +66,14 @@ def test_communicativity():
         assert True
 
 
-if 1:
+if 0:
     def setup_neighbours(positions, particle_count, char_length, x):
         charges = np.random.rand(particle_count, 1)
         sigma = np.ones((particle_count, 1))
         epsilon_lj = np.ones((particle_count, 1))
         system = nbp.System(characteristic_length=char_length,
-                sigma=sigma, epsilon_lj=epsilon_lj, particle_charges=charges, positions=positions,
-                lj=True, ewald=True, use_neighbours=True)
+                            sigma=sigma, epsilon_lj=epsilon_lj, particle_charges=charges, positions=positions,
+                            lj=True, ewald=True, use_neighbours=True)
         neighbours = nbp.Neighbours(system.info(), system.state(), system, verbose=False)
         neighbours_list = neighbours.get_neighbours(x)
 

--- a/nbp/tests/test_neighbours.py
+++ b/nbp/tests/test_neighbours.py
@@ -32,7 +32,7 @@ def test_no_self_in_neighbours():
 
     self_in_neighbours = []
     for particle, position in enumerate(system.state().positions()):
-        result = system.state().neighbours().get_neighbours(position)
+        result = system.state().neighbours().get_neighbours(particle)
         if particle in result.nb_ID:
             self_in_neighbours.append(True)
         else:
@@ -51,8 +51,7 @@ def test_communicativity():
         print('Neighbours of particle {0}: {1}'.format(particle, nb_ID))
         print('Distances from particle {0}: {1}'.format(particle, nb_dist))
         for neighbour_index, neighbour in enumerate(nb_ID):
-            neighbour_result = system.state().neighbours().get_neighbours(
-                system.state().positions()[neighbour])
+            neighbour_result = system.state().neighbours().get_neighbours(neighbour)
             neighbour_neighbours = neighbour_result.nb_ID
             neighbour_dist = neighbour_result.nb_dist
             print('Neighbours of particle {0}: {1}'.format(neighbour, neighbour_neighbours))


### PR DESCRIPTION
The neighbours are now saved in a dictionary. There is one with the distances and one which contains the index of the neighbours. The key is simply the particle number. The changes do not have an impact on the functionality when get_neighbours is called. The only change in sysmodule.py is a parameter name to clarify its meaning. 

If there are no Issues with this version I would like to merge it. 

